### PR TITLE
Functorize SectionList

### DIFF
--- a/src/components/sectionListRe.re
+++ b/src/components/sectionListRe.re
@@ -1,92 +1,153 @@
 external view : ReactRe.reactClass = "SectionList" [@@bs.module "react-native"];
 
-type section 'item =
-  Js.t {
-    .
-    data : array 'item, key : Js.Undefined.t string, renderItem : Js.Undefined.t (renderItem 'item)
-  }
-and renderItem 'item =
-  Js.t {
-    .
-    item : 'item,
-    index : int,
-    section : section 'item,
-    separators :
-      Js.t {
-        .
-        highlight : unit => unit,
-        unhighlight : unit => unit,
-        updateProps : string => Js.t {.} => unit
-      }
-  } =>
-  ReactRe.reactElement
-and separatorProps 'item =
-  Js.t {
-    .
-    highlighted : Js.boolean,
-    leadingItem : Js.Undefined.t 'item,
-    leadingSection : Js.Undefined.t (section 'item),
-    section : section 'item,
-    trailingItem : Js.Undefined.t 'item,
-    trailingSection : Js.Undefined.t (section 'item)
-  }
-and viewToken 'item =
-  Js.t {
-    .
-    item : 'item,
-    key : string,
-    index : Js.undefined int,
-    isViewable : Js.boolean,
-    section : section 'item
+module Make (Item: {type item;}) => {
+  type section =
+    Js.t {
+      .
+      data : array Item.item,
+      key : Js.Undefined.t string,
+      renderItem :
+        Js.Undefined.t (
+          Js.t {
+            .
+            item : Item.item,
+            index : int,
+            section : section,
+            separators : Js.t {. highlight : unit => unit, unhighlight : unit => unit}
+          } =>
+          ReactRe.reactElement
+        )
+    };
+  type viewToken =
+    Js.t {
+      .
+      item : Item.item,
+      key : string,
+      index : Js.undefined int,
+      isViewable : Js.boolean,
+      section : section
+    };
+  type renderBag = {
+    item: Item.item,
+    index: int,
+    section,
+    separators: Js.t {. highlight : unit => unit, unhighlight : unit => unit}
   };
-
-let section ::data ::key=? ::renderItem=? () => {
-  "data": data,
-  "key": Js.Undefined.from_opt key,
-  "renderItem": Js.Undefined.from_opt renderItem
+  type separatorProps = {
+    highlighted: bool,
+    leadingItem: option Item.item,
+    leadingSection: option section,
+    section,
+    trailingItem: option Item.item,
+    trailingSection: option section
+  };
+  let createRenderBag ::item ::index ::section ::separators => {item, index, section, separators};
+  let createSeparatorProps
+      ::highlighted
+      ::leadingItem
+      ::leadingSection
+      ::section
+      ::trailingItem
+      ::trailingSection => {
+    highlighted,
+    leadingItem,
+    leadingSection,
+    section,
+    trailingItem,
+    trailingSection
+  };
+  module SectionList = {
+    let section ::data ::key=? ::renderItem=? () =>
+      Js.Undefined.({"data": data, "key": from_opt key, "renderItem": from_opt renderItem});
+    let createElement:
+      sections::array section =>
+      renderItem::(renderBag => ReactRe.reactElement) =>
+      keyExtractor::(Item.item => int => string) =>
+      itemSeparatorComponent::(separatorProps => ReactRe.reactElement)? =>
+      listEmptyComponent::(unit => ReactRe.reactElement)? =>
+      listFooterComponent::ReactRe.reactElement? =>
+      listHeaderComponent::ReactRe.reactElement? =>
+      sectionSeparatorComponent::(separatorProps => ReactRe.reactElement)? =>
+      extraData::'extraData? =>
+      initialNumToRender::int? =>
+      onEndReached::Js.t {. distanceFromEnd : float}? =>
+      onEndReachedThreshold::float? =>
+      onViewableItemsChanged::Js.t {. viewableItems : array viewToken, changed : array viewToken}? =>
+      onRefresh::(unit => unit)? =>
+      refreshing::bool? =>
+      renderSectionHeader::(Js.t {. section : section} => ReactRe.reactElement)? =>
+      renderSectionFooter::(Js.t {. section : section} => ReactRe.reactElement)? =>
+      stickySectionHeadersEnabled::bool? =>
+      children::list ReactRe.reactElement =>
+      ref::(ReactRe.reactRef => unit)? =>
+      key::string? =>
+      unit =>
+      ReactRe.reactElement =
+      fun ::sections
+          ::renderItem
+          ::keyExtractor
+          ::itemSeparatorComponent=?
+          ::listEmptyComponent=?
+          ::listFooterComponent=?
+          ::listHeaderComponent=?
+          ::sectionSeparatorComponent=?
+          ::extraData=?
+          ::initialNumToRender=?
+          ::onEndReached=?
+          ::onEndReachedThreshold=?
+          ::onViewableItemsChanged=?
+          ::onRefresh=?
+          ::refreshing=?
+          ::renderSectionHeader=?
+          ::renderSectionFooter=?
+          ::stickySectionHeadersEnabled=? =>
+        ReactRe.wrapPropsShamelessly
+          view
+          Js.Undefined.(
+            {
+              "sections": sections,
+              "renderItem": fun jsItems =>
+                renderItem (
+                  createRenderBag
+                    item::jsItems##item
+                    index::jsItems##index
+                    section::jsItems##section
+                    separators::jsItems##separators
+                ),
+              "keyExtractor": keyExtractor,
+              "itemSeparatorComponent":
+                from_opt (
+                  Utils.option_map
+                    (
+                      fun itemSeparatorComponent jsItems =>
+                        itemSeparatorComponent (
+                          createSeparatorProps
+                            highlighted::jsItems##highlighted
+                            leadingItem::jsItems##leadingItem
+                            leadingSection::jsItems##leadingSection
+                            section::jsItems##section
+                            trailingItem::jsItems##trailingItem
+                            trailingSection::jsItems##trailingSection
+                        )
+                    )
+                    itemSeparatorComponent
+                ),
+              "listEmptyComponent": from_opt listEmptyComponent,
+              "listFooterComponent": from_opt listFooterComponent,
+              "listHeaderComponent": from_opt listHeaderComponent,
+              "sectionSeparatorComponent": from_opt sectionSeparatorComponent,
+              "extraData": from_opt extraData,
+              "initialNumToRender": from_opt initialNumToRender,
+              "onEndReached": from_opt onEndReached,
+              "onEndReachedThreshold": from_opt onEndReachedThreshold,
+              "onRefresh": from_opt onRefresh,
+              "onViewableItemsChanged": from_opt onViewableItemsChanged,
+              "refreshing": from_opt (Utils.optBoolToOptJsBoolean refreshing),
+              "renderSectionHeader": from_opt renderSectionHeader,
+              "renderSectionFooter": from_opt renderSectionFooter,
+              "stickySectionHeadersEnabled":
+                from_opt (Utils.optBoolToOptJsBoolean stickySectionHeadersEnabled)
+            }
+          );
+  };
 };
-
-let createElement
-    ::sections
-    ::renderItem
-    ::itemSeparatorComponent=?
-    ::listEmptyComponent=?
-    ::listFooterComponent=?
-    ::listHeaderComponent=?
-    ::sectionSeparatorComponent=?
-    ::extraData=?
-    ::initialNumToRender=?
-    ::keyExtractor=?
-    ::onEndReached=?
-    ::onEndReachedThreshold=?
-    ::onViewableItemsChanged=?
-    ::onRefresh=?
-    ::refreshing=?
-    ::renderSectionHeader=?
-    ::renderSectionFooter=?
-    ::stickySectionHeadersEnabled=? =>
-  ReactRe.wrapPropsShamelessly
-    view
-    Js.Undefined.(
-      {
-        "sections": sections,
-        "renderItem": renderItem,
-        "itemSeparatorComponent": from_opt itemSeparatorComponent,
-        "listEmptyComponent": from_opt listEmptyComponent,
-        "listFooterComponent": from_opt listFooterComponent,
-        "listHeaderComponent": from_opt listHeaderComponent,
-        "sectionSeparatorComponent": from_opt sectionSeparatorComponent,
-        "extraData": from_opt extraData,
-        "initialNumToRender": from_opt initialNumToRender,
-        "keyExtractor": from_opt keyExtractor,
-        "onEndReached": from_opt onEndReached,
-        "onEndReachedThreshold": from_opt onEndReachedThreshold,
-        "onRefresh": from_opt onRefresh,
-        "onViewableItemsChanged": from_opt onViewableItemsChanged,
-        "refreshing": from_opt (Utils.optBoolToOptJsBoolean refreshing),
-        "renderSectionHeader": from_opt renderSectionHeader,
-        "renderSectionFooter": from_opt renderSectionFooter,
-        "stickySectionHeadersEnabled":
-          from_opt (Utils.optBoolToOptJsBoolean stickySectionHeadersEnabled)
-      }
-    );

--- a/src/components/sectionListRe.re
+++ b/src/components/sectionListRe.re
@@ -112,27 +112,30 @@ module CreateComponent (Item: {type item;}) => {
                   sections,
               "renderItem": renderItemFromJS renderItem,
               "keyExtractor": keyExtractor,
-              "itemSeparatorComponent":
+              "ItemSeparatorComponent":
                 from_opt (
                   Utils.option_map
                     (
-                      fun itemSeparatorComponent jsItems =>
-                        itemSeparatorComponent (
-                          createSeparatorProps
-                            highlighted::jsItems##highlighted
-                            leadingItem::jsItems##leadingItem
-                            leadingSection::jsItems##leadingSection
-                            section::jsItems##section
-                            trailingItem::jsItems##trailingItem
-                            trailingSection::jsItems##trailingSection
-                        )
+                      fun itemSeparatorComponent => {
+                        let comp jsItems =>
+                          itemSeparatorComponent (
+                            createSeparatorProps
+                              highlighted::(Js.to_bool jsItems##highlighted)
+                              leadingItem::jsItems##leadingItem
+                              leadingSection::jsItems##leadingSection
+                              section::jsItems##section
+                              trailingItem::jsItems##trailingItem
+                              trailingSection::jsItems##trailingSection
+                          );
+                        comp
+                      }
                     )
                     itemSeparatorComponent
                 ),
-              "listEmptyComponent": from_opt listEmptyComponent,
-              "listFooterComponent": from_opt listFooterComponent,
-              "listHeaderComponent": from_opt listHeaderComponent,
-              "sectionSeparatorComponent": from_opt sectionSeparatorComponent,
+              "ListEmptyComponent": from_opt listEmptyComponent,
+              "ListFooterComponent": from_opt listFooterComponent,
+              "ListHeaderComponent": from_opt listHeaderComponent,
+              "SectionSeparatorComponent": from_opt sectionSeparatorComponent,
               "extraData": from_opt extraData,
               "initialNumToRender": from_opt initialNumToRender,
               "onEndReached": from_opt onEndReached,

--- a/src/components/sectionListRe.rei
+++ b/src/components/sectionListRe.rei
@@ -1,23 +1,17 @@
-module Make:
+module CreateComponent:
   (Item: {type item;}) =>
   {
-    type section =
-      Js.t {
-        .
-        data : array Item.item,
-        key : Js.Undefined.t string,
-        renderItem :
-          Js.Undefined.t (
-            Js.t {
-              .
-              index : int,
-              item : Item.item,
-              section : section,
-              separators : Js.t {. highlight : unit => unit, unhighlight : unit => unit}
-            } =>
-            ReactRe.reactElement
-          )
-      };
+    type renderBag = {
+      item: Item.item,
+      index: int,
+      section,
+      separators: Js.t {. highlight : unit => unit, unhighlight : unit => unit}
+    }
+    and section = {
+      data: array Item.item,
+      key: option string,
+      renderItem: option (renderBag => ReactRe.reactElement)
+    };
     type viewToken =
       Js.t {
         .
@@ -27,12 +21,6 @@ module Make:
         key : string,
         section : section
       };
-    type renderBag = {
-      item: Item.item,
-      index: int,
-      section,
-      separators: Js.t {. highlight : unit => unit, unhighlight : unit => unit}
-    };
     type separatorProps = {
       highlighted: bool,
       leadingItem: option Item.item,
@@ -43,11 +31,11 @@ module Make:
     };
     module SectionList: {
       let section:
-        data::'a =>
-        key::'b? =>
-        renderItem::'c? =>
+        data::array Item.item =>
+        key::string? =>
+        renderItem::(renderBag => ReactRe.reactElement)? =>
         unit =>
-        Js.t {. data : 'a, key : Js.Undefined.t 'b, renderItem : Js.Undefined.t 'c};
+        section;
       let createElement:
         sections::array section =>
         renderItem::(renderBag => ReactRe.reactElement) =>

--- a/src/components/sectionListRe.rei
+++ b/src/components/sectionListRe.rei
@@ -1,68 +1,76 @@
-type section 'item =
-  Js.t {
-    .
-    data : array 'item, key : Js.Undefined.t string, renderItem : Js.Undefined.t (renderItem 'item)
-  }
-and renderItem 'item =
-  Js.t {
-    .
-    item : 'item,
-    index : int,
-    section : section 'item,
-    separators :
+module Make:
+  (Item: {type item;}) =>
+  {
+    type section =
       Js.t {
         .
-        highlight : unit => unit,
-        unhighlight : unit => unit,
-        updateProps : string => Js.t {.} => unit
-      }
-  } =>
-  ReactRe.reactElement
-and separatorProps 'item =
-  Js.t {
-    .
-    highlighted : Js.boolean,
-    leadingItem : Js.Undefined.t 'item,
-    leadingSection : Js.Undefined.t (section 'item),
-    section : section 'item,
-    trailingItem : Js.Undefined.t 'item,
-    trailingSection : Js.Undefined.t (section 'item)
-  }
-and viewToken 'item =
-  Js.t {
-    .
-    item : 'item,
-    key : string,
-    index : Js.undefined int,
-    isViewable : Js.boolean,
-    section : section 'item
+        data : array Item.item,
+        key : Js.Undefined.t string,
+        renderItem :
+          Js.Undefined.t (
+            Js.t {
+              .
+              index : int,
+              item : Item.item,
+              section : section,
+              separators : Js.t {. highlight : unit => unit, unhighlight : unit => unit}
+            } =>
+            ReactRe.reactElement
+          )
+      };
+    type viewToken =
+      Js.t {
+        .
+        index : Js.undefined int,
+        isViewable : Js.boolean,
+        item : Item.item,
+        key : string,
+        section : section
+      };
+    type renderBag = {
+      item: Item.item,
+      index: int,
+      section,
+      separators: Js.t {. highlight : unit => unit, unhighlight : unit => unit}
+    };
+    type separatorProps = {
+      highlighted: bool,
+      leadingItem: option Item.item,
+      leadingSection: option section,
+      section,
+      trailingItem: option Item.item,
+      trailingSection: option section
+    };
+    module SectionList: {
+      let section:
+        data::'a =>
+        key::'b? =>
+        renderItem::'c? =>
+        unit =>
+        Js.t {. data : 'a, key : Js.Undefined.t 'b, renderItem : Js.Undefined.t 'c};
+      let createElement:
+        sections::array section =>
+        renderItem::(renderBag => ReactRe.reactElement) =>
+        keyExtractor::(Item.item => int => string) =>
+        itemSeparatorComponent::(separatorProps => ReactRe.reactElement)? =>
+        listEmptyComponent::(unit => ReactRe.reactElement)? =>
+        listFooterComponent::ReactRe.reactElement? =>
+        listHeaderComponent::ReactRe.reactElement? =>
+        sectionSeparatorComponent::(separatorProps => ReactRe.reactElement)? =>
+        extraData::'extraData? =>
+        initialNumToRender::int? =>
+        onEndReached::Js.t {. distanceFromEnd : float}? =>
+        onEndReachedThreshold::float? =>
+        onViewableItemsChanged::Js.t {. changed : array viewToken, viewableItems : array viewToken}? =>
+        onRefresh::(unit => unit)? =>
+        refreshing::bool? =>
+        renderSectionHeader::(Js.t {. section : section} => ReactRe.reactElement)? =>
+        renderSectionFooter::(Js.t {. section : section} => ReactRe.reactElement)? =>
+        stickySectionHeadersEnabled::bool? =>
+        children::list ReactRe.reactElement =>
+        ref::(ReactRe.reactRef => unit)? =>
+        key::string? =>
+        unit =>
+        ReactRe.reactElement;
+    };
   };
-
-let section:
-  data::array 'item => key::string? => renderItem::renderItem 'item? => unit => section 'item;
-
-let createElement:
-  sections::array (section 'item) =>
-  renderItem::renderItem 'item =>
-  itemSeparatorComponent::(separatorProps 'item => ReactRe.reactElement)? =>
-  listEmptyComponent::(unit => ReactRe.reactElement)? =>
-  listFooterComponent::ReactRe.reactElement? =>
-  listHeaderComponent::ReactRe.reactElement? =>
-  sectionSeparatorComponent::(separatorProps 'item => ReactRe.reactElement)? =>
-  extraData::'extraData? =>
-  initialNumToRender::int? =>
-  keyExtractor::('item => int => string)? =>
-  onEndReached::Js.t {. distanceFromEnd : float}? =>
-  onEndReachedThreshold::float? =>
-  onViewableItemsChanged::
-    Js.t {. viewableItems : array (viewToken 'item), changed : array (viewToken 'item)}? =>
-  onRefresh::(unit => unit)? =>
-  refreshing::bool? =>
-  renderSectionHeader::(Js.t {. section : section 'item} => ReactRe.reactElement)? =>
-  renderSectionFooter::(Js.t {. section : section 'item} => ReactRe.reactElement)? =>
-  stickySectionHeadersEnabled::bool? =>
-  children::list ReactRe.reactElement =>
-  ref::(ReactRe.reactRef => unit)? =>
-  key::string? =>
-  unit =>
-  ReactRe.reactElement;


### PR DESCRIPTION
The previous Version doesn't had a satisfying user experience.

 ### Previously
```reason

module UIExplorerApp = {
  include ReactRe.Component;
  type props = {components: array ExampleList.item};
  let name = "UIExplorerExampleList";

  let renderItem sectionProps => {
      <Text>(ReactRe.stringToElement (sectionProps##item: ExampleList.item).key)</Text>
  };

  let render {props} => { 
      <View style=styles##listContainer>
        <SectionList
            sections=[| SectionList.section data::props.components key::"components"  ()|]
            renderItem=renderItem
           keyExtractor=(fun item _ => item.key)
        />
    </View>  
    };
};

include ReactRe.CreateComponent UIExplorerApp;
```
Notice that the compiler cannot infer the type of `item` in `renderItem`.

First I changed that `renderItem` takes a record instead of a `Js.t ...` object since I found the sudden contact with the FFI akward and now it resembles more the usual `render` function.

This resulted in the problem that a pattern match is only possible if the record is defined in the same module (without explicit annotation).
To get everything working as I want, I had to pick bigger weapons. 

### Now
```reason

module UIExplorerApp = {
  include ReactRe.Component;
  include SectionList.Make {type item = ExampleList.item };
  type props = {components: array ExampleList.item};
  let name = "UIExplorerExampleList";
  let renderItem {item} => <Text> (ReactRe.stringToElement item.key) </Text>;
  let render {props} =>
    <View style=styles##listContainer>
      <SectionList
        sections=[|SectionList.section data::props.components key::"components" ()|]
        renderItem
        keyExtractor=(fun item _ => item.key)
      />
    </View>;
};

include ReactRe.CreateComponent UIExplorerApp;
```

The `SectionList` module is now a functor which just takes its `item` type as argument.
We include the resulting module to get the type definitions in the current module.
Our ReactComponent has again the `SectionList` module name which overwrites the `SectionList` from `ReactNative`.