### PR TITLE
Improve nativeModule API to return Js.t 'a

### DIFF
--- a/src/nativeEventEmitterRe.re
+++ b/src/nativeEventEmitterRe.re
@@ -2,10 +2,10 @@ type t;
 
 type emitterSubscription;
 
-external create : NativeModules.t => t =
+external create : NativeModules.t 'a => t =
   "NativeEventEmitter" [@@bs.new] [@@bs.module "react-native"];
 
-external addListener : t => string => (Js.Dict.t 'a => unit) => emitterSubscription = "" [@@bs.send];
+external addListener : t => string => ('a => unit) => emitterSubscription = "" [@@bs.send];
 
 external removeAllListeners : t => string => unit = "" [@@bs.send];
 

--- a/src/nativeEventEmitterRe.rei
+++ b/src/nativeEventEmitterRe.rei
@@ -2,9 +2,9 @@ type t;
 
 type emitterSubscription;
 
-let create: NativeModules.t => t;
+let create: NativeModules.t 'a => t;
 
-let addListener: t => string => (Js.Dict.t 'a => unit) => emitterSubscription;
+let addListener: t => string => ('a => unit) => emitterSubscription;
 
 let removeAllListeners: t => string => unit;
 

--- a/src/nativeModulesRe.re
+++ b/src/nativeModulesRe.re
@@ -1,8 +1,8 @@
-type t;
+type t 'a = Js.t 'a;
 
 external nativeModules : Js.Dict.t 'a = "NativeModules" [@@bs.module "react-native"];
 
-let _get name: t => Js.Dict.unsafeGet nativeModules name;
+let _get name: t 'a => Js.Dict.unsafeGet nativeModules name;
 
 let get name => _get name;
 

--- a/src/nativeModulesRe.rei
+++ b/src/nativeModulesRe.rei
@@ -1,3 +1,2 @@
-type t;
-
-let get: string => t;
+type t 'a = Js.t 'a;
+let get: string => t 'a;


### PR DESCRIPTION
The previous API used `Js.Dict` for args which has homogeneous values. Thanks to the change to `Js.t 'a` both syntax is nicer (using the `##` operator) and values can be of different types.