### PR TITLE
Improve RNTester setup

### DIFF
--- a/RNTester/.gitignore
+++ b/RNTester/.gitignore
@@ -1,4 +1,5 @@
 lib/
+react-native/
 yarn.lock
 
 # OSX

--- a/RNTester/README.md
+++ b/RNTester/README.md
@@ -8,12 +8,13 @@ Before running the app, make sure you ran:
 
     # in this folder
     npm install
+    # start Bucklescript compiler in watch mode
+    npm run watch
 
 ### Running on iOS
 
 Mac OS and Xcode are required.
 
-- Open a new tab in your terminal and start the bucklescript watcher with `npm run watch`
 - Open `RNTester/RNTester.xcodeproj` in Xcode
 - Hit the Run button
 
@@ -25,7 +26,6 @@ You'll need to have all the [prerequisites](https://github.com/facebook/react-na
 
 Start an Android emulator ([Genymotion](https://www.genymotion.com) is recommended).
 
-- Open a new tab in your terminal and start the bucklescript watcher with `npm run watch`
 - `./gradlew :RNTester:android:app:installDebug`
 `
 _Note: Building for the first time can take a while._

--- a/RNTester/README.md
+++ b/RNTester/README.md
@@ -8,20 +8,14 @@ Before running the app, make sure you ran:
 
     # in this folder
     npm install
-    # and in the toplevel folder
-    cd ..
-    npm install
 
 ### Running on iOS
 
 Mac OS and Xcode are required.
 
-- Start the packager with `npm start` **[important]**
 - Open a new tab in your terminal and start the bucklescript watcher with `npm run watch`
 - Open `RNTester/RNTester.xcodeproj` in Xcode
 - Hit the Run button
-
-**Note:** If the packager starts automatically (e.g. from Xcode) close it and follow the instructions above.
 
 See [Running on device](https://facebook.github.io/react-native/docs/running-on-device.html) if you want to use a physical device.
 
@@ -31,7 +25,6 @@ You'll need to have all the [prerequisites](https://github.com/facebook/react-na
 
 Start an Android emulator ([Genymotion](https://www.genymotion.com) is recommended).
 
-- Start the packager with `npm start` **[important]**
 - Open a new tab in your terminal and start the bucklescript watcher with `npm run watch`
 - `./gradlew :RNTester:android:app:installDebug`
 `

--- a/RNTester/bsconfig.json
+++ b/RNTester/bsconfig.json
@@ -7,6 +7,11 @@
     "sources": [{
         "dir": "src",
         "subdirs": {
+            "dir": "examples"
+        }
+    }, {
+        "dir": "react-native",
+        "subdirs": {
             "dir": "components"
         }
     }]

--- a/RNTester/index.ios.js
+++ b/RNTester/index.ios.js
@@ -4,7 +4,7 @@
  * @flow
  */
 
-import { comp as App } from "../lib/js/RNTester/src/rNTesterApp.js";
+import { comp as App } from "./lib/js/src/rNTesterApp.js";
 import React from "react";
 import {
   AppRegistry

--- a/RNTester/package.json
+++ b/RNTester/package.json
@@ -3,19 +3,22 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "build": "../node_modules/.bin/bsb -clean-world -make-world",
-    "packager:start": "node node_modules/react-native/local-cli/cli.js start --root '../lib/js,../node_modules'",
-    "watch": "../node_modules/.bin/bsb -w",
+    "build": "node scripts/copy.js && bsb -clean-world -make-world",
+    "packager:start": "node node_modules/react-native/local-cli/cli.js start",
+    "watch": "node scripts/copy.js && bsb -clean-world -make-world -w",
     "start": "npm run build && npm run packager:start",
     "test": "jest"
   },
   "dependencies": {
     "react": "16.0.0-alpha.6",
-    "react-native": "0.44.0"
+    "react-native": "0.44.0",
+    "reason-react": "^0.1.3",
+    "bs-platform": "^1.7.0"
   },
   "devDependencies": {
     "babel-jest": "20.0.0",
-    "babel-preset-react-native": "1.9.1"
+    "babel-preset-react-native": "1.9.1",
+    "fs-extra": "^3.0.1"
   },
   "jest": {
     "preset": "react-native"

--- a/RNTester/package.json
+++ b/RNTester/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "node scripts/copy.js",
     "build": "node scripts/copy.js && bsb -clean-world -make-world",
     "packager:start": "node node_modules/react-native/local-cli/cli.js start",
     "watch": "node scripts/copy.js && bsb -clean-world -make-world -w",

--- a/RNTester/scripts/copy.js
+++ b/RNTester/scripts/copy.js
@@ -1,0 +1,5 @@
+const fs = require("fs-extra");
+const path = require("path");
+
+fs.ensureDirSync(path.join(__dirname, "../react-native"));
+fs.copySync(path.join(__dirname, "../../src"), path.join(__dirname, "../react-native"));


### PR DESCRIPTION
Previously I did all kind of magic with the RN Packager, but this was again somehow broken.

Now RNTester app just copies all `src` files from the bindings into the `RNTester` folder.