### PR TITLE
SectionList API

### DIFF
--- a/RNTester/src/RNTesterExampleList.re
+++ b/RNTester/src/RNTesterExampleList.re
@@ -21,37 +21,36 @@ let styles =
       }
     );
 
-include
-  SectionList.CreateComponent {
-    type item = ExampleList.item;
-  };
-
 let component = ReasonReact.statelessComponent "RNTesterExampleList";
 
-let make = {
-  let renderItem onPress {item} =>
-    <TouchableHighlight onPress=(fun () => onPress item)>
-      <View style=styles##row>
-        <Text style=styles##rowTitleText> (ReasonReact.stringToElement item.title) </Text>
-        <Text style=styles##rowDetailText> (ReasonReact.stringToElement item.description) </Text>
-      </View>
-    </TouchableHighlight>;
-  let itemSeparatorComponent {highlighted} =>
-    <View
-      style=(
-              if highlighted {
-                styles##separatorHighlighted
-              } else {
-                styles##separator
-              }
-            )
-    />;
-  fun ::components ::onPress _children => {
+let renderItem onPress =>
+  SectionList.renderItem (
+    fun {item} =>
+      <TouchableHighlight onPress=(fun () => onPress item)>
+        <View style=styles##row>
+          <Text style=styles##rowTitleText>
+            (ReasonReact.stringToElement item.ExampleList.title)
+          </Text>
+          <Text style=styles##rowDetailText> (ReasonReact.stringToElement item.description) </Text>
+        </View>
+      </TouchableHighlight>
+  );
+
+let itemSeparatorComponent =
+  SectionList.separatorComponent (
+    fun {highlighted} =>
+      <View style=(highlighted ? styles##separatorHighlighted : styles##separator) />
+  );
+
+let make ::components ::onPress _children => {
+  let sections =
+    SectionList.sections [|SectionList.section data::components key::"components" ()|];
+  {
     ...component,
     render: fun _state _self =>
       <View style=styles##listContainer>
         <SectionList
-          sections=[|SectionList.section data::components key::"components" ()|]
+          sections
           renderItem=(renderItem onPress)
           keyExtractor=(fun item _ => item.key)
           itemSeparatorComponent

--- a/src/components/sectionListRe.re
+++ b/src/components/sectionListRe.re
@@ -1,151 +1,178 @@
 external view : ReasonReact.reactClass = "SectionList" [@@bs.module "react-native"];
 
-module CreateComponent (Item: {type item;}) => {
-  type renderBag = {
-    item: Item.item,
-    index: int,
-    section,
-    separators: Js.t {. highlight : unit => unit, unhighlight : unit => unit}
+type jsSection 'item =
+  Js.t {
+    .
+    data : array 'item,
+    key : Js.Undefined.t string,
+    renderItem : Js.Undefined.t (jsRenderBag 'item => ReasonReact.reactElement)
   }
-  and section = {
-    data: array Item.item,
-    key: option string,
-    renderItem: option (renderBag => ReasonReact.reactElement)
+and jsRenderBag 'item =
+  Js.t {
+    .
+    item : 'item,
+    index : int,
+    section : jsSection 'item,
+    separators : Js.t {. highlight : unit => unit, unhighlight : unit => unit}
   };
-  type viewToken =
-    Js.t {
-      .
-      item : Item.item,
-      key : string,
-      index : Js.undefined int,
-      isViewable : Js.boolean,
-      section : section
-    };
-  type separatorProps = {
-    highlighted: bool,
-    leadingItem: option Item.item,
-    leadingSection: option section,
-    section,
-    trailingItem: option Item.item,
-    trailingSection: option section
+
+type jsSeparatorProps 'item =
+  Js.t {
+    .
+    highlighted : Js.boolean,
+    leadingItem : Js.Undefined.t 'item,
+    leadingSection : Js.Undefined.t (jsSection 'item),
+    section : jsSection 'item,
+    trailingItem : Js.Undefined.t 'item,
+    trailingSection : Js.Undefined.t (jsSection 'item)
   };
-  let createRenderBag ::item ::index ::section ::separators => {item, index, section, separators};
-  let createSeparatorProps
-      ::highlighted
-      ::leadingItem
-      ::leadingSection
-      ::section
-      ::trailingItem
-      ::trailingSection => {
-    highlighted,
-    leadingItem,
-    leadingSection,
-    section,
-    trailingItem,
-    trailingSection
-  };
-  module SectionList = {
-    let renderItemFromJS renderItem jsItems =>
-      renderItem (
-        createRenderBag
-          item::jsItems##item
-          index::jsItems##index
-          section::jsItems##section
-          separators::jsItems##separators
-      );
-    let section ::data ::key=? ::renderItem=? () => {data, key, renderItem};
-    let make:
-      sections::array section =>
-      renderItem::(renderBag => ReasonReact.reactElement) =>
-      keyExtractor::(Item.item => int => string) =>
-      itemSeparatorComponent::(separatorProps => ReasonReact.reactElement)? =>
-      listEmptyComponent::(unit => ReasonReact.reactElement)? =>
-      listFooterComponent::ReasonReact.reactElement? =>
-      listHeaderComponent::ReasonReact.reactElement? =>
-      sectionSeparatorComponent::(separatorProps => ReasonReact.reactElement)? =>
-      extraData::'extraData? =>
-      initialNumToRender::int? =>
-      onEndReached::Js.t {. distanceFromEnd : float}? =>
-      onEndReachedThreshold::float? =>
-      onViewableItemsChanged::Js.t {. viewableItems : array viewToken, changed : array viewToken}? =>
-      onRefresh::(unit => unit)? =>
-      refreshing::bool? =>
-      renderSectionHeader::(Js.t {. section : section} => ReasonReact.reactElement)? =>
-      renderSectionFooter::(Js.t {. section : section} => ReasonReact.reactElement)? =>
-      stickySectionHeadersEnabled::bool? =>
-      array ReasonReact.reactElement =>
-      ReasonReact.component ReasonReact.stateless =
-      fun ::sections
-          ::renderItem
-          ::keyExtractor
-          ::itemSeparatorComponent=?
-          ::listEmptyComponent=?
-          ::listFooterComponent=?
-          ::listHeaderComponent=?
-          ::sectionSeparatorComponent=?
-          ::extraData=?
-          ::initialNumToRender=?
-          ::onEndReached=?
-          ::onEndReachedThreshold=?
-          ::onViewableItemsChanged=?
-          ::onRefresh=?
-          ::refreshing=?
-          ::renderSectionHeader=?
-          ::renderSectionFooter=?
-          ::stickySectionHeadersEnabled=? =>
-        ReasonReact.wrapJsForReason
-          reactClass::view
-          props::
-            Js.Undefined.(
-              {
-                "sections":
-                  Array.map
-                    (
-                      fun {data, key, renderItem} => {
-                        "data": data,
-                        "key": from_opt key,
-                        "renderItem": from_opt (UtilsRN.option_map renderItemFromJS renderItem)
-                      }
-                    )
-                    sections,
-                "renderItem": renderItemFromJS renderItem,
-                "keyExtractor": keyExtractor,
-                "ItemSeparatorComponent":
-                  from_opt (
-                    UtilsRN.option_map
-                      (
-                        fun itemSeparatorComponent => {
-                          let comp jsItems =>
-                            itemSeparatorComponent (
-                              createSeparatorProps
-                                highlighted::(Js.to_bool jsItems##highlighted)
-                                leadingItem::jsItems##leadingItem
-                                leadingSection::jsItems##leadingSection
-                                section::jsItems##section
-                                trailingItem::jsItems##trailingItem
-                                trailingSection::jsItems##trailingSection
-                            );
-                          comp
-                        }
-                      )
-                      itemSeparatorComponent
-                  ),
-                "ListEmptyComponent": from_opt listEmptyComponent,
-                "ListFooterComponent": from_opt listFooterComponent,
-                "ListHeaderComponent": from_opt listHeaderComponent,
-                "SectionSeparatorComponent": from_opt sectionSeparatorComponent,
-                "extraData": from_opt extraData,
-                "initialNumToRender": from_opt initialNumToRender,
-                "onEndReached": from_opt onEndReached,
-                "onEndReachedThreshold": from_opt onEndReachedThreshold,
-                "onRefresh": from_opt onRefresh,
-                "onViewableItemsChanged": from_opt onViewableItemsChanged,
-                "refreshing": from_opt (UtilsRN.optBoolToOptJsBoolean refreshing),
-                "renderSectionHeader": from_opt renderSectionHeader,
-                "renderSectionFooter": from_opt renderSectionFooter,
-                "stickySectionHeadersEnabled":
-                  from_opt (UtilsRN.optBoolToOptJsBoolean stickySectionHeadersEnabled)
-              }
-            );
-  };
+
+type renderBag 'item = {
+  item: 'item,
+  index: int,
+  section: section 'item,
+  separators: Js.t {. highlight : unit => unit, unhighlight : unit => unit}
+}
+and section 'item = {
+  data: array 'item,
+  key: option string,
+  renderItem: option (renderBag 'item => ReasonReact.reactElement)
 };
+
+type separatorProps 'item = {
+  highlighted: bool,
+  leadingItem: option 'item,
+  leadingSection: option (section 'item),
+  section: section 'item,
+  trailingItem: option 'item,
+  trailingSection: option (section 'item)
+};
+
+type renderItem 'item = jsRenderBag 'item => ReasonReact.reactElement;
+
+let jsSectionToSection jsSection => {
+  data: jsSection##data,
+  key: Js.Undefined.to_opt jsSection##key,
+  /** We set renderItem to None to avoid an infinite conversion loop */
+  renderItem: None
+};
+
+type sections 'item = array (jsSection 'item);
+
+let renderItem (reRenderItem: renderBag 'item => ReasonReact.reactElement) :renderItem 'item =>
+  fun (jsRenderBag: jsRenderBag 'item) =>
+    reRenderItem {
+      item: jsRenderBag##item,
+      index: jsRenderBag##index,
+      section: jsSectionToSection jsRenderBag##section,
+      separators: jsRenderBag##separators
+    };
+
+let section ::data ::key=? ::renderItem=? () => {data, key, renderItem};
+
+let sections reSections :sections 'item =>
+  Array.map
+    (
+      fun reSection => {
+        "data": reSection.data,
+        "key": Js.Undefined.from_opt reSection.key,
+        "renderItem": Js.Undefined.from_opt (UtilsRN.option_map renderItem reSection.renderItem)
+      }
+    )
+    reSections;
+
+type separatorComponent 'item = jsSeparatorProps 'item => ReasonReact.reactElement;
+
+let separatorComponent
+    (reSeparatorComponent: separatorProps 'item => ReasonReact.reactElement)
+    :separatorComponent 'item =>
+  fun (jsSeparatorProps: jsSeparatorProps 'item) =>
+    reSeparatorComponent {
+      highlighted: Js.to_bool jsSeparatorProps##highlighted,
+      leadingItem: Js.Undefined.to_opt jsSeparatorProps##leadingItem,
+      leadingSection:
+        Js.Undefined.to_opt jsSeparatorProps##leadingSection |>
+        UtilsRN.option_map jsSectionToSection,
+      section: jsSectionToSection jsSeparatorProps##section,
+      trailingItem: Js.Undefined.to_opt jsSeparatorProps##trailingItem,
+      trailingSection:
+        Js.Undefined.to_opt jsSeparatorProps##trailingSection |>
+        UtilsRN.option_map jsSectionToSection
+    };
+
+type viewToken 'item =
+  Js.t {
+    .
+    item : 'item,
+    key : string,
+    index : Js.undefined int,
+    isViewable : Js.boolean,
+    section : section 'item
+  };
+
+let make:
+  sections::sections 'item =>
+  renderItem::renderItem 'item =>
+  keyExtractor::('item => int => string) =>
+  itemSeparatorComponent::separatorComponent 'item? =>
+  listEmptyComponent::(unit => ReasonReact.reactElement)? =>
+  listFooterComponent::ReasonReact.reactElement? =>
+  listHeaderComponent::ReasonReact.reactElement? =>
+  sectionSeparatorComponent::separatorComponent 'item? =>
+  extraData::'extraData? =>
+  initialNumToRender::int? =>
+  onEndReached::Js.t {. distanceFromEnd : float}? =>
+  onEndReachedThreshold::float? =>
+  onViewableItemsChanged::
+    Js.t {. viewableItems : array (viewToken 'item), changed : array (viewToken 'item)}? =>
+  onRefresh::(unit => unit)? =>
+  refreshing::bool? =>
+  renderSectionHeader::(Js.t {. section : section 'item} => ReasonReact.reactElement)? =>
+  renderSectionFooter::(Js.t {. section : section 'item} => ReasonReact.reactElement)? =>
+  stickySectionHeadersEnabled::bool? =>
+  array ReasonReact.reactElement =>
+  ReasonReact.component ReasonReact.stateless =
+  fun ::sections
+      ::renderItem
+      ::keyExtractor
+      ::itemSeparatorComponent=?
+      ::listEmptyComponent=?
+      ::listFooterComponent=?
+      ::listHeaderComponent=?
+      ::sectionSeparatorComponent=?
+      ::extraData=?
+      ::initialNumToRender=?
+      ::onEndReached=?
+      ::onEndReachedThreshold=?
+      ::onViewableItemsChanged=?
+      ::onRefresh=?
+      ::refreshing=?
+      ::renderSectionHeader=?
+      ::renderSectionFooter=?
+      ::stickySectionHeadersEnabled=? =>
+    ReasonReact.wrapJsForReason
+      reactClass::view
+      props::
+        Js.Undefined.(
+          {
+            "sections": sections,
+            "renderItem": renderItem,
+            "keyExtractor": keyExtractor,
+            "ItemSeparatorComponent": from_opt itemSeparatorComponent,
+            "ListEmptyComponent": from_opt listEmptyComponent,
+            "ListFooterComponent": from_opt listFooterComponent,
+            "ListHeaderComponent": from_opt listHeaderComponent,
+            "SectionSeparatorComponent": from_opt sectionSeparatorComponent,
+            "extraData": from_opt extraData,
+            "initialNumToRender": from_opt initialNumToRender,
+            "onEndReached": from_opt onEndReached,
+            "onEndReachedThreshold": from_opt onEndReachedThreshold,
+            "onRefresh": from_opt onRefresh,
+            "onViewableItemsChanged": from_opt onViewableItemsChanged,
+            "refreshing": from_opt (UtilsRN.optBoolToOptJsBoolean refreshing),
+            "renderSectionHeader": from_opt renderSectionHeader,
+            "renderSectionFooter": from_opt renderSectionFooter,
+            "stickySectionHeadersEnabled":
+              from_opt (UtilsRN.optBoolToOptJsBoolean stickySectionHeadersEnabled)
+          }
+        );

--- a/src/components/sectionListRe.rei
+++ b/src/components/sectionListRe.rei
@@ -1,61 +1,73 @@
-module CreateComponent:
-  (Item: {type item;}) =>
-  {
-    type renderBag = {
-      item: Item.item,
-      index: int,
-      section,
-      separators: Js.t {. highlight : unit => unit, unhighlight : unit => unit}
-    }
-    and section = {
-      data: array Item.item,
-      key: option string,
-      renderItem: option (renderBag => ReasonReact.reactElement)
-    };
-    type viewToken =
-      Js.t {
-        .
-        index : Js.undefined int,
-        isViewable : Js.boolean,
-        item : Item.item,
-        key : string,
-        section : section
-      };
-    type separatorProps = {
-      highlighted: bool,
-      leadingItem: option Item.item,
-      leadingSection: option section,
-      section,
-      trailingItem: option Item.item,
-      trailingSection: option section
-    };
-    module SectionList: {
-      let section:
-        data::array Item.item =>
-        key::string? =>
-        renderItem::(renderBag => ReasonReact.reactElement)? =>
-        unit =>
-        section;
-      let make:
-        sections::array section =>
-        renderItem::(renderBag => ReasonReact.reactElement) =>
-        keyExtractor::(Item.item => int => string) =>
-        itemSeparatorComponent::(separatorProps => ReasonReact.reactElement)? =>
-        listEmptyComponent::(unit => ReasonReact.reactElement)? =>
-        listFooterComponent::ReasonReact.reactElement? =>
-        listHeaderComponent::ReasonReact.reactElement? =>
-        sectionSeparatorComponent::(separatorProps => ReasonReact.reactElement)? =>
-        extraData::'extraData? =>
-        initialNumToRender::int? =>
-        onEndReached::Js.t {. distanceFromEnd : float}? =>
-        onEndReachedThreshold::float? =>
-        onViewableItemsChanged::Js.t {. changed : array viewToken, viewableItems : array viewToken}? =>
-        onRefresh::(unit => unit)? =>
-        refreshing::bool? =>
-        renderSectionHeader::(Js.t {. section : section} => ReasonReact.reactElement)? =>
-        renderSectionFooter::(Js.t {. section : section} => ReasonReact.reactElement)? =>
-        stickySectionHeadersEnabled::bool? =>
-        array ReasonReact.reactElement =>
-        ReasonReact.component ReasonReact.stateless;
-    };
+type renderBag 'item = {
+  item: 'item,
+  index: int,
+  section: section 'item,
+  separators: Js.t {. highlight : unit => unit, unhighlight : unit => unit}
+}
+and section 'item = {
+  data: array 'item,
+  key: option string,
+  renderItem: option (renderBag 'item => ReasonReact.reactElement)
+};
+
+let section:
+  data::array 'item =>
+  key::string? =>
+  renderItem::(renderBag 'item => ReasonReact.reactElement)? =>
+  unit =>
+  section 'item;
+
+type separatorProps 'item = {
+  highlighted: bool,
+  leadingItem: option 'item,
+  leadingSection: option (section 'item),
+  section: section 'item,
+  trailingItem: option 'item,
+  trailingSection: option (section 'item)
+};
+
+type sections 'item;
+
+let sections: array (section 'item) => sections 'item;
+
+type renderItem 'item;
+
+let renderItem: (renderBag 'item => ReasonReact.reactElement) => renderItem 'item;
+
+type separatorComponent 'item;
+
+let separatorComponent:
+  (separatorProps 'item => ReasonReact.reactElement) => separatorComponent 'item;
+
+type viewToken 'item =
+  Js.t {
+    .
+    index : Js.undefined int,
+    isViewable : Js.boolean,
+    item : 'item,
+    key : string,
+    section : section 'item
   };
+
+let make:
+  sections::sections 'item =>
+  renderItem::renderItem 'item =>
+  keyExtractor::('item => int => string) =>
+  itemSeparatorComponent::separatorComponent 'item? =>
+  listEmptyComponent::(unit => ReasonReact.reactElement)? =>
+  listFooterComponent::ReasonReact.reactElement? =>
+  listHeaderComponent::ReasonReact.reactElement? =>
+  sectionSeparatorComponent::separatorComponent 'item? =>
+  extraData::'extraData? =>
+  initialNumToRender::int? =>
+  onEndReached::Js.t {. distanceFromEnd : float}? =>
+  onEndReachedThreshold::float? =>
+  onViewableItemsChanged::
+    Js.t {. changed : array (viewToken 'item), viewableItems : array (viewToken 'item)}? =>
+  onRefresh::(unit => unit)? =>
+  refreshing::bool? =>
+  renderSectionHeader::(Js.t {. section : section 'item} => ReasonReact.reactElement)? =>
+  renderSectionFooter::(Js.t {. section : section 'item} => ReasonReact.reactElement)? =>
+  stickySectionHeadersEnabled::bool? =>
+  array ReasonReact.reactElement =>
+  ReasonReact.component ReasonReact.stateless;


### PR DESCRIPTION
Adressing #11.
I wasn't really happy with the SectionList API, especially since Reason-React isn't functor based anymore.
Another thing which came in mind: We conversted from records to `Js.t 'a` in render, but this also created a new function each time, i.e. quite bad for performance. I now moved all conversions to separate functions and made the prop types abstract. [Here](https://github.com/BuckleTypes/bs-react-native/blob/5ca9819929e8a2900d0cc88a86e60889030a9d30/RNTester/src/RNTesterExampleList.re#L26) is an example.

One problem we ran into earlier was that we could deconstruct the `renderBag` but then the compiler couldn't access `item.foo`. I now learned that you can qualify things with `item.MyModule.foo` and everything works superb :)