### PR TITLE
Add missing props for Image, Modal

### DIFF
--- a/src/components/Image.res
+++ b/src/components/Image.res
@@ -110,6 +110,7 @@ type props = {
   referrerPolicy?: referrerPolicy,
   resizeMethod?: resizeMethod,
   resizeMode?: Style.resizeMode,
+  resizeMultiplier?: float,
   source: Source.t,
   srcSet?: string,
   style?: Style.t,

--- a/src/components/Modal.res
+++ b/src/components/Modal.res
@@ -34,7 +34,9 @@ external make: (
   ~ref: ref=?,
   // Modal props
   ~animationType: animationType=?,
+  ~backdropColor: Color.t=?,
   ~hardwareAccelerated: bool=?,
+  ~navigationBarTranslucent: bool=?,
   ~onDismiss: unit => unit=?,
   ~onOrientationChange: orientationChangeEvent => unit=?,
   ~onRequestClose: unit => unit=?,


### PR DESCRIPTION

- Image
   - resizeMultiplier (since 0.76: https://reactnative.dev/docs/0.76/image#resizemultiplier-android)
- Modal
   - backdropColor (since 0.77: https://reactnative.dev/docs/0.77/modal#backdropcolor)
   - navigationBarTranslucent (since 0.77: https://reactnative.dev/docs/0.77/modal#navigationbartranslucent-android)
