### PR TITLE
add `notUndefined` attribute to `Style.size` type

### DIFF
--- a/src/apis/Style.resi
+++ b/src/apis/Style.resi
@@ -6,6 +6,7 @@ external arrayOption: array<option<t>> => t = "%identity"
 external unsafeAddStyle: (@as(json`{}`) _, t, {..}) => t = "Object.assign"
 external unsafeStyle: {..} => t = "%identity"
 
+@notUndefined
 type size
 
 external dp: float => size = "%identity"


### PR DESCRIPTION
In some cases `Primitive_option.some(x)` wrappers were added, because the compiler could not prove the abstract type of `size` to never contain `undefined`.

https://rescript-lang.org/try/?version=v12.0.0-rc.3&module=esmodule&code=PTAEAEDsHsBcFVIBMCmAzAlpFSBQsBPABxVAGcMAvFXXFAD1hQCdIBDAG1CSIC5Q0HaG1igAvAD5yVUmNAAiAKQZUkWBkLzahEuUIdZoAN4AjOLGgBbAPz8K1AL7bipMgAs2zHADVOAVxQAHgByNik5I0s-WDYTA1AAN38UflCnXHBLaCQ-AwAKeS82AGNYAFp2dQSUMqLIDEsRHHkASjpGFnYuPzIUAGUPLyRfDgDUtnEpd08fZJCw8QUe-sHZ0ZQtXANRNnrGpiQAeTQ0XtE5ZYGZ4eS8gEYABgeAOjatlFE0SEW8lsnjXCgUBmWAWSz8Hh5XYNJpHE5nZ5JdYtAA0uCcQA