### PR TITLE
DOM Node APIs

### DIFF
--- a/src/apis/AccessibilityInfo.res
+++ b/src/apis/AccessibilityInfo.res
@@ -67,8 +67,10 @@ type accessibilityEventTypes = [
 ]
 
 @scope("AccessibilityInfo") @module("react-native")
-external sendAccessibilityEvent: (NativeElement.ref, accessibilityEventTypes) => unit =
-  "sendAccessibilityEvent"
+external sendAccessibilityEvent: (
+  Ref.t<DOMAPI.element<'nativeElement>>,
+  accessibilityEventTypes,
+) => unit = "sendAccessibilityEvent"
 
 @scope("AccessibilityInfo") @module("react-native")
 external prefersCrossFadeTransitions: unit => promise<bool> = "prefersCrossFadeTransitions"

--- a/src/components/ActivityIndicator.bs.js
+++ b/src/components/ActivityIndicator.bs.js
@@ -2,5 +2,6 @@
 
 var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
 
+NativeElement$ReactNative.Impl({});
 
-/* NativeElement-ReactNative Not a pure module */
+/*  Not a pure module */

--- a/src/components/ActivityIndicator.res
+++ b/src/components/ActivityIndicator.res
@@ -1,4 +1,10 @@
-include NativeElement
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asActivityIndicatorElement: DOMAPI.anyElement => element = "%identity"
 
 @unboxed
 type size = | @as("small") Small | @as("large") Large | Number(float)

--- a/src/components/ActivityIndicator.res
+++ b/src/components/ActivityIndicator.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asActivityIndicatorElement: DOMAPI.anyElement => element = "%identity"
-
 @unboxed
 type size = | @as("small") Small | @as("large") Large | Number(float)
 

--- a/src/components/Button.bs.js
+++ b/src/components/Button.bs.js
@@ -2,5 +2,6 @@
 
 var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
 
+NativeElement$ReactNative.Impl({});
 
-/* NativeElement-ReactNative Not a pure module */
+/*  Not a pure module */

--- a/src/components/Button.res
+++ b/src/components/Button.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asButtonElement: DOMAPI.anyElement => element = "%identity"
-
 type props = {
   ref?: ref,
   accessibilityActions?: array<Accessibility.actionInfo>,

--- a/src/components/Button.res
+++ b/src/components/Button.res
@@ -1,4 +1,10 @@
-include NativeElement
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asButtonElement: DOMAPI.anyElement => element = "%identity"
 
 type props = {
   ref?: ref,

--- a/src/components/Image.bs.js
+++ b/src/components/Image.bs.js
@@ -3,6 +3,8 @@
 var Event$ReactNative = require("../apis/Event.bs.js");
 var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
 
+NativeElement$ReactNative.Impl({});
+
 var Source = {};
 
 Event$ReactNative.SyntheticEvent({});

--- a/src/components/Image.res
+++ b/src/components/Image.res
@@ -1,4 +1,10 @@
-include NativeElement
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asImageElement: DOMAPI.anyElement => element = "%identity"
 
 type cache = [
   | #default

--- a/src/components/Image.res
+++ b/src/components/Image.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asImageElement: DOMAPI.anyElement => element = "%identity"
-
 type cache = [
   | #default
   | #reload

--- a/src/components/ImageBackground.bs.js
+++ b/src/components/ImageBackground.bs.js
@@ -2,5 +2,6 @@
 
 var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
 
+NativeElement$ReactNative.Impl({});
 
-/* NativeElement-ReactNative Not a pure module */
+/*  Not a pure module */

--- a/src/components/ImageBackground.res
+++ b/src/components/ImageBackground.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asImageBackgroundElement: DOMAPI.anyElement => element = "%identity"
-
 type props = {
   ref?: ref,
   imageRef?: Image.ref,

--- a/src/components/ImageBackground.res
+++ b/src/components/ImageBackground.res
@@ -1,4 +1,10 @@
-include NativeElement
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asImageBackgroundElement: DOMAPI.anyElement => element = "%identity"
 
 type props = {
   ref?: ref,

--- a/src/components/KeyboardAvoidingView.bs.js
+++ b/src/components/KeyboardAvoidingView.bs.js
@@ -2,5 +2,6 @@
 
 var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
 
+NativeElement$ReactNative.Impl({});
 
-/* NativeElement-ReactNative Not a pure module */
+/*  Not a pure module */

--- a/src/components/KeyboardAvoidingView.res
+++ b/src/components/KeyboardAvoidingView.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asKeyboardAvoidingViewElement: DOMAPI.anyElement => element = "%identity"
-
 type behavior = [#height | #position | #padding]
 
 type props = {

--- a/src/components/KeyboardAvoidingView.res
+++ b/src/components/KeyboardAvoidingView.res
@@ -1,4 +1,10 @@
-include NativeElement
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asKeyboardAvoidingViewElement: DOMAPI.anyElement => element = "%identity"
 
 type behavior = [#height | #position | #padding]
 

--- a/src/components/Modal.bs.js
+++ b/src/components/Modal.bs.js
@@ -3,6 +3,8 @@
 var Event$ReactNative = require("../apis/Event.bs.js");
 var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
 
+NativeElement$ReactNative.Impl({});
+
 Event$ReactNative.SyntheticEvent({});
 
 var OrientationChangeEvent = {};

--- a/src/components/Modal.res
+++ b/src/components/Modal.res
@@ -1,4 +1,10 @@
-include NativeElement
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asModalElement: DOMAPI.anyElement => element = "%identity"
 
 type orientation = [
   | #landscape

--- a/src/components/Modal.res
+++ b/src/components/Modal.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asModalElement: DOMAPI.anyElement => element = "%identity"
-
 type orientation = [
   | #landscape
   | #"landscape-left"

--- a/src/components/Pressable.bs.js
+++ b/src/components/Pressable.bs.js
@@ -2,5 +2,6 @@
 
 var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
 
+NativeElement$ReactNative.Impl({});
 
-/* NativeElement-ReactNative Not a pure module */
+/*  Not a pure module */

--- a/src/components/Pressable.res
+++ b/src/components/Pressable.res
@@ -1,4 +1,10 @@
-include NativeElement
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asPressableElement: DOMAPI.anyElement => element = "%identity"
 
 type rippleConfig = {
   borderless?: bool,

--- a/src/components/Pressable.res
+++ b/src/components/Pressable.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asPressableElement: DOMAPI.anyElement => element = "%identity"
-
 type rippleConfig = {
   borderless?: bool,
   color?: Color.t,

--- a/src/components/ProgressBarAndroid.bs.js
+++ b/src/components/ProgressBarAndroid.bs.js
@@ -2,5 +2,6 @@
 
 var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
 
+NativeElement$ReactNative.Impl({});
 
-/* NativeElement-ReactNative Not a pure module */
+/*  Not a pure module */

--- a/src/components/ProgressBarAndroid.res
+++ b/src/components/ProgressBarAndroid.res
@@ -1,4 +1,10 @@
-include NativeElement
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asProgressBarAndroidElement: DOMAPI.anyElement => element = "%identity"
 
 type styleAttr = [
   | #Horizontal

--- a/src/components/ProgressBarAndroid.res
+++ b/src/components/ProgressBarAndroid.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asProgressBarAndroidElement: DOMAPI.anyElement => element = "%identity"
-
 type styleAttr = [
   | #Horizontal
   | #Normal

--- a/src/components/RefreshControl.bs.js
+++ b/src/components/RefreshControl.bs.js
@@ -2,5 +2,6 @@
 
 var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
 
+NativeElement$ReactNative.Impl({});
 
-/* NativeElement-ReactNative Not a pure module */
+/*  Not a pure module */

--- a/src/components/RefreshControl.res
+++ b/src/components/RefreshControl.res
@@ -1,4 +1,10 @@
-include NativeElement
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asRefreshControlElement: DOMAPI.anyElement => element = "%identity"
 
 type props = {
   ref?: ref,

--- a/src/components/RefreshControl.res
+++ b/src/components/RefreshControl.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asRefreshControlElement: DOMAPI.anyElement => element = "%identity"
-
 type props = {
   ref?: ref,
   ...View.viewProps,

--- a/src/components/SafeAreaView.bs.js
+++ b/src/components/SafeAreaView.bs.js
@@ -2,5 +2,6 @@
 
 var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
 
+NativeElement$ReactNative.Impl({});
 
-/* NativeElement-ReactNative Not a pure module */
+/*  Not a pure module */

--- a/src/components/SafeAreaView.res
+++ b/src/components/SafeAreaView.res
@@ -1,4 +1,10 @@
-include NativeElement
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asSafeAreaViewElement: DOMAPI.anyElement => element = "%identity"
 
 type props = {
   ref?: ref,

--- a/src/components/SafeAreaView.res
+++ b/src/components/SafeAreaView.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asSafeAreaViewElement: DOMAPI.anyElement => element = "%identity"
-
 type props = {
   ref?: ref,
   ...View.viewProps,

--- a/src/components/Switch.bs.js
+++ b/src/components/Switch.bs.js
@@ -2,5 +2,6 @@
 
 var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
 
+NativeElement$ReactNative.Impl({});
 
-/* NativeElement-ReactNative Not a pure module */
+/*  Not a pure module */

--- a/src/components/Switch.res
+++ b/src/components/Switch.res
@@ -1,4 +1,10 @@
-include NativeElement
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asSwitchElement: DOMAPI.anyElement => element = "%identity"
 
 type trackColor = {
   \"true"?: Color.t,

--- a/src/components/Switch.res
+++ b/src/components/Switch.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asSwitchElement: DOMAPI.anyElement => element = "%identity"
-
 type trackColor = {
   \"true"?: Color.t,
   \"false"?: Color.t,

--- a/src/components/Text.bs.js
+++ b/src/components/Text.bs.js
@@ -2,5 +2,6 @@
 
 var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
 
+NativeElement$ReactNative.Impl({});
 
-/* NativeElement-ReactNative Not a pure module */
+/*  Not a pure module */

--- a/src/components/Text.res
+++ b/src/components/Text.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asTextElement: DOMAPI.anyElement => element = "%identity"
-
 type android_hyphenationFrequency = [
   | #normal
   | #none

--- a/src/components/Text.res
+++ b/src/components/Text.res
@@ -1,4 +1,10 @@
-include NativeElement
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asTextElement: DOMAPI.anyElement => element = "%identity"
 
 type android_hyphenationFrequency = [
   | #normal

--- a/src/components/TouchableHighlight.bs.js
+++ b/src/components/TouchableHighlight.bs.js
@@ -2,5 +2,6 @@
 
 var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
 
+NativeElement$ReactNative.Impl({});
 
-/* NativeElement-ReactNative Not a pure module */
+/*  Not a pure module */

--- a/src/components/TouchableHighlight.res
+++ b/src/components/TouchableHighlight.res
@@ -1,4 +1,10 @@
-include NativeElement
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asTouchableHighlightElement: DOMAPI.anyElement => element = "%identity"
 
 type props = {
   ref?: ref,

--- a/src/components/TouchableHighlight.res
+++ b/src/components/TouchableHighlight.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asTouchableHighlightElement: DOMAPI.anyElement => element = "%identity"
-
 type props = {
   ref?: ref,
   ...TouchableWithoutFeedback.coreProps,

--- a/src/components/TouchableNativeFeedback.bs.js
+++ b/src/components/TouchableNativeFeedback.bs.js
@@ -2,7 +2,9 @@
 
 var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
 
+NativeElement$ReactNative.Impl({});
+
 var Background = {};
 
 exports.Background = Background;
-/* NativeElement-ReactNative Not a pure module */
+/*  Not a pure module */

--- a/src/components/TouchableNativeFeedback.res
+++ b/src/components/TouchableNativeFeedback.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asTouchableNativeFeedbackElement: DOMAPI.anyElement => element = "%identity"
-
 module Background = {
   type t
 

--- a/src/components/TouchableNativeFeedback.res
+++ b/src/components/TouchableNativeFeedback.res
@@ -1,4 +1,10 @@
-include NativeElement
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asTouchableNativeFeedbackElement: DOMAPI.anyElement => element = "%identity"
 
 module Background = {
   type t

--- a/src/components/TouchableWithoutFeedback.bs.js
+++ b/src/components/TouchableWithoutFeedback.bs.js
@@ -2,5 +2,6 @@
 
 var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
 
+NativeElement$ReactNative.Impl({});
 
-/* NativeElement-ReactNative Not a pure module */
+/*  Not a pure module */

--- a/src/components/TouchableWithoutFeedback.res
+++ b/src/components/TouchableWithoutFeedback.res
@@ -1,4 +1,10 @@
-include NativeElement
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asTouchableWithoutFeedbackElement: DOMAPI.anyElement => element = "%identity"
 
 type coreProps = {
   accessible?: bool,

--- a/src/components/TouchableWithoutFeedback.res
+++ b/src/components/TouchableWithoutFeedback.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asTouchableWithoutFeedbackElement: DOMAPI.anyElement => element = "%identity"
-
 type coreProps = {
   accessible?: bool,
   accessibilityElementsHidden?: bool,

--- a/src/components/View.bs.js
+++ b/src/components/View.bs.js
@@ -2,5 +2,6 @@
 
 var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
 
+NativeElement$ReactNative.Impl({});
 
-/* NativeElement-ReactNative Not a pure module */
+/*  Not a pure module */

--- a/src/components/View.res
+++ b/src/components/View.res
@@ -1,4 +1,10 @@
-include NativeElement
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asViewElement: DOMAPI.anyElement => element = "%identity"
 
 // @todo in 0.71.0
 // after adding `aria-*` props, make sure `aria-checked` can be true, false or "mixed"

--- a/src/components/View.res
+++ b/src/components/View.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asViewElement: DOMAPI.anyElement => element = "%identity"
-
 // @todo in 0.71.0
 // after adding `aria-*` props, make sure `aria-checked` can be true, false or "mixed"
 

--- a/src/elements/DrawerLayoutAndroidElement.bs.js
+++ b/src/elements/DrawerLayoutAndroidElement.bs.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var NativeMethods$ReactNative = require("./NativeMethods.bs.js");
+var NativeElement$ReactNative = require("./NativeElement.bs.js");
 var DrawerLayoutAndroidMethods$ReactNative = require("./DrawerLayoutAndroidMethods.bs.js");
 
-DrawerLayoutAndroidMethods$ReactNative.Make({});
+NativeElement$ReactNative.Impl({});
 
-NativeMethods$ReactNative.Make({});
+DrawerLayoutAndroidMethods$ReactNative.Make({});
 
 /*  Not a pure module */

--- a/src/elements/DrawerLayoutAndroidElement.res
+++ b/src/elements/DrawerLayoutAndroidElement.res
@@ -1,10 +1,11 @@
-type element
-type ref = Ref.t<element>
+type nativeElement
 
-include DrawerLayoutAndroidMethods.Make({
-  type t = element
+include NativeElement.Impl({
+  type t = nativeElement
 })
 
-include NativeMethods.Make({
+external asDrawerLayoutAndroidElement: DOMAPI.anyElement => element = "%identity"
+
+include DrawerLayoutAndroidMethods.Make({
   type t = element
 })

--- a/src/elements/DrawerLayoutAndroidElement.res
+++ b/src/elements/DrawerLayoutAndroidElement.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asDrawerLayoutAndroidElement: DOMAPI.anyElement => element = "%identity"
-
 include DrawerLayoutAndroidMethods.Make({
   type t = element
 })

--- a/src/elements/NativeElement.bs.js
+++ b/src/elements/NativeElement.bs.js
@@ -9,5 +9,9 @@ function Impl(T) {
   return {};
 }
 
+NativeMethods$ReactNative.Make({});
+
+DOMAPI$ReactNative.$$Element.Impl({});
+
 exports.Impl = Impl;
-/* No side effect */
+/*  Not a pure module */

--- a/src/elements/NativeElement.bs.js
+++ b/src/elements/NativeElement.bs.js
@@ -11,7 +11,5 @@ function Impl(T) {
 
 NativeMethods$ReactNative.Make({});
 
-DOMAPI$ReactNative.$$Element.Impl({});
-
 exports.Impl = Impl;
 /*  Not a pure module */

--- a/src/elements/NativeElement.bs.js
+++ b/src/elements/NativeElement.bs.js
@@ -3,8 +3,11 @@
 var DOMAPI$ReactNative = require("../types/DOMAPI.bs.js");
 var NativeMethods$ReactNative = require("./NativeMethods.bs.js");
 
-NativeMethods$ReactNative.Make({});
+function Impl(T) {
+  NativeMethods$ReactNative.Make({});
+  DOMAPI$ReactNative.$$Element.Impl({});
+  return {};
+}
 
-DOMAPI$ReactNative.$$Element.Impl({});
-
-/*  Not a pure module */
+exports.Impl = Impl;
+/* No side effect */

--- a/src/elements/NativeElement.bs.js
+++ b/src/elements/NativeElement.bs.js
@@ -1,7 +1,10 @@
 'use strict';
 
+var DOMAPI$ReactNative = require("../types/DOMAPI.bs.js");
 var NativeMethods$ReactNative = require("./NativeMethods.bs.js");
 
 NativeMethods$ReactNative.Make({});
+
+DOMAPI$ReactNative.$$Element.Impl({});
 
 /*  Not a pure module */

--- a/src/elements/NativeElement.res
+++ b/src/elements/NativeElement.res
@@ -17,9 +17,7 @@ module Impl = (
   })
 }
 
-@deprecated(
-  "Bindings maintainers: please use NativeElement.Impl instead of accessing element type directly."
-)
+@deprecated("Use NativeElement.Impl instead of accessing element type directly.")
 type element
 
 @warning("-3")

--- a/src/elements/NativeElement.res
+++ b/src/elements/NativeElement.res
@@ -6,6 +6,8 @@ module Impl = (
   type element = DOMAPI.element<T.t>
   type ref = Ref.t<element>
 
+  external unsafeFromAnyElement: DOMAPI.anyElement => element = "%identity"
+
   include NativeMethods.Make({
     type t = element
   })

--- a/src/elements/NativeElement.res
+++ b/src/elements/NativeElement.res
@@ -1,6 +1,10 @@
-type element
+type element = DOMAPI.element
 type ref = Ref.t<element>
 
 include NativeMethods.Make({
+  type t = element
+})
+
+include DOMAPI.Element.Impl({
   type t = element
 })

--- a/src/elements/NativeElement.res
+++ b/src/elements/NativeElement.res
@@ -18,8 +18,14 @@ module Impl = (
 }
 
 @deprecated(
-  "Bindings maintainers: please use NativeElement.Impl instead of accessing the types directly."
+  "Bindings maintainers: please use NativeElement.Impl instead of accessing element type directly."
 )
-include Impl({
-  type t = DOMAPI.anyElement
+type element
+
+@warning("-3")
+type ref = Ref.t<element>
+
+@warning("-3")
+include NativeMethods.Make({
+  type t = element
 })

--- a/src/elements/NativeElement.res
+++ b/src/elements/NativeElement.res
@@ -1,10 +1,16 @@
-type element = DOMAPI.element
-type ref = Ref.t<element>
+module Impl = (
+  T: {
+    type t
+  },
+) => {
+  type element = DOMAPI.element<T.t>
+  type ref = Ref.t<element>
 
-include NativeMethods.Make({
-  type t = element
-})
+  include NativeMethods.Make({
+    type t = element
+  })
 
-include DOMAPI.Element.Impl({
-  type t = element
-})
+  include DOMAPI.Element.Impl({
+    type t = element
+  })
+}

--- a/src/elements/NativeElement.res
+++ b/src/elements/NativeElement.res
@@ -14,3 +14,10 @@ module Impl = (
     type t = element
   })
 }
+
+@deprecated(
+  "Bindings maintainers: please use NativeElement.Impl instead of accessing the types directly."
+)
+include Impl({
+  type t = DOMAPI.anyElement
+})

--- a/src/elements/ScrollViewElement.bs.js
+++ b/src/elements/ScrollViewElement.bs.js
@@ -1,6 +1,9 @@
 'use strict';
 
+var NativeElement$ReactNative = require("./NativeElement.bs.js");
 var ScrollViewMethods$ReactNative = require("./ScrollViewMethods.bs.js");
+
+NativeElement$ReactNative.Impl({});
 
 ScrollViewMethods$ReactNative.Make({});
 

--- a/src/elements/ScrollViewElement.res
+++ b/src/elements/ScrollViewElement.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asScrollViewElement: DOMAPI.anyElement => element = "%identity"
-
 include ScrollViewMethods.Make({
   type t = element
 })

--- a/src/elements/ScrollViewElement.res
+++ b/src/elements/ScrollViewElement.res
@@ -1,5 +1,10 @@
-type element
-type ref = Ref.t<element>
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asScrollViewElement: DOMAPI.anyElement => element = "%identity"
 
 include ScrollViewMethods.Make({
   type t = element

--- a/src/elements/TextInputElement.bs.js
+++ b/src/elements/TextInputElement.bs.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var NativeMethods$ReactNative = require("./NativeMethods.bs.js");
+var NativeElement$ReactNative = require("./NativeElement.bs.js");
 var TextInputMethods$ReactNative = require("./TextInputMethods.bs.js");
 
-TextInputMethods$ReactNative.Make({});
+NativeElement$ReactNative.Impl({});
 
-NativeMethods$ReactNative.Make({});
+TextInputMethods$ReactNative.Make({});
 
 /*  Not a pure module */

--- a/src/elements/TextInputElement.res
+++ b/src/elements/TextInputElement.res
@@ -1,10 +1,11 @@
-type element
-type ref = Ref.t<element>
+type nativeElement
 
-include TextInputMethods.Make({
-  type t = element
+include NativeElement.Impl({
+  type t = nativeElement
 })
 
-include NativeMethods.Make({
+external asTextInputElement: DOMAPI.anyElement => element = "%identity"
+
+include TextInputMethods.Make({
   type t = element
 })

--- a/src/elements/TextInputElement.res
+++ b/src/elements/TextInputElement.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asTextInputElement: DOMAPI.anyElement => element = "%identity"
-
 include TextInputMethods.Make({
   type t = element
 })

--- a/src/elements/TouchableOpacityElement.bs.js
+++ b/src/elements/TouchableOpacityElement.bs.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var NativeMethods$ReactNative = require("./NativeMethods.bs.js");
+var NativeElement$ReactNative = require("./NativeElement.bs.js");
 var TouchableOpacityMethods$ReactNative = require("./TouchableOpacityMethods.bs.js");
 
-TouchableOpacityMethods$ReactNative.Make({});
+NativeElement$ReactNative.Impl({});
 
-NativeMethods$ReactNative.Make({});
+TouchableOpacityMethods$ReactNative.Make({});
 
 /*  Not a pure module */

--- a/src/elements/TouchableOpacityElement.res
+++ b/src/elements/TouchableOpacityElement.res
@@ -1,10 +1,11 @@
-type element
-type ref = Ref.t<element>
+type nativeElement
 
-include TouchableOpacityMethods.Make({
-  type t = element
+include NativeElement.Impl({
+  type t = nativeElement
 })
 
-include NativeMethods.Make({
+external asTouchableOpacityElement: DOMAPI.anyElement => element = "%identity"
+
+include TouchableOpacityMethods.Make({
   type t = element
 })

--- a/src/elements/TouchableOpacityElement.res
+++ b/src/elements/TouchableOpacityElement.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asTouchableOpacityElement: DOMAPI.anyElement => element = "%identity"
-
 include TouchableOpacityMethods.Make({
   type t = element
 })

--- a/src/elements/VirtualizedListElement.bs.js
+++ b/src/elements/VirtualizedListElement.bs.js
@@ -1,7 +1,10 @@
 'use strict';
 
+var NativeElement$ReactNative = require("./NativeElement.bs.js");
 var ScrollViewMethods$ReactNative = require("./ScrollViewMethods.bs.js");
 var VirtualizedListMethods$ReactNative = require("./VirtualizedListMethods.bs.js");
+
+NativeElement$ReactNative.Impl({});
 
 VirtualizedListMethods$ReactNative.Make({});
 

--- a/src/elements/VirtualizedListElement.res
+++ b/src/elements/VirtualizedListElement.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asVirtualizedListElement: DOMAPI.anyElement => element = "%identity"
-
 include VirtualizedListMethods.Make({
   type t = element
 })

--- a/src/elements/VirtualizedListElement.res
+++ b/src/elements/VirtualizedListElement.res
@@ -1,5 +1,10 @@
-type element
-type ref = Ref.t<element>
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asVirtualizedListElement: DOMAPI.anyElement => element = "%identity"
 
 include VirtualizedListMethods.Make({
   type t = element

--- a/src/elements/VirtualizedSectionListElement.bs.js
+++ b/src/elements/VirtualizedSectionListElement.bs.js
@@ -1,6 +1,9 @@
 'use strict';
 
+var NativeElement$ReactNative = require("./NativeElement.bs.js");
 var VirtualizedSectionListMethods$ReactNative = require("./VirtualizedSectionListMethods.bs.js");
+
+NativeElement$ReactNative.Impl({});
 
 VirtualizedSectionListMethods$ReactNative.Make({});
 

--- a/src/elements/VirtualizedSectionListElement.res
+++ b/src/elements/VirtualizedSectionListElement.res
@@ -4,8 +4,6 @@ include NativeElement.Impl({
   type t = nativeElement
 })
 
-external asVirtualizedSectionListElement: DOMAPI.anyElement => element = "%identity"
-
 include VirtualizedSectionListMethods.Make({
   type t = element
 })

--- a/src/elements/VirtualizedSectionListElement.res
+++ b/src/elements/VirtualizedSectionListElement.res
@@ -1,5 +1,10 @@
-type element
-type ref = Ref.t<element>
+type nativeElement
+
+include NativeElement.Impl({
+  type t = nativeElement
+})
+
+external asVirtualizedSectionListElement: DOMAPI.anyElement => element = "%identity"
 
 include VirtualizedSectionListMethods.Make({
   type t = element

--- a/src/types/DOMAPI.bs.js
+++ b/src/types/DOMAPI.bs.js
@@ -25,7 +25,7 @@ var $$Document = {};
 
 var $$Text = {};
 
-function findNodeType(node) {
+function classify(node) {
   switch (node.nodeType) {
     case 1 :
         return {
@@ -47,8 +47,8 @@ function findNodeType(node) {
   }
 }
 
-var NodeTypeHelper = {
-  findNodeType: findNodeType
+var NodeType = {
+  classify: classify
 };
 
 exports.$$NodeList = $$NodeList;
@@ -57,5 +57,5 @@ exports.$$Node = $$Node;
 exports.$$Element = $$Element;
 exports.$$Document = $$Document;
 exports.$$Text = $$Text;
-exports.NodeTypeHelper = NodeTypeHelper;
+exports.NodeType = NodeType;
 /* No side effect */

--- a/src/types/DOMAPI.bs.js
+++ b/src/types/DOMAPI.bs.js
@@ -1,0 +1,61 @@
+'use strict';
+
+
+var $$NodeList = {};
+
+var $$HTMLCollection = {};
+
+function Impl(T) {
+  return {};
+}
+
+var $$Node = {
+  Impl: Impl
+};
+
+function Impl$1(T) {
+  return {};
+}
+
+var $$Element = {
+  Impl: Impl$1
+};
+
+var $$Document = {};
+
+var $$Text = {};
+
+function findNodeType(node) {
+  switch (node.nodeType) {
+    case 1 :
+        return {
+                TAG: "Element",
+                _0: node
+              };
+    case 3 :
+        return {
+                TAG: "Text",
+                _0: node
+              };
+    case 9 :
+        return {
+                TAG: "Document",
+                _0: node
+              };
+    default:
+      return "Unknown";
+  }
+}
+
+var NodeTypeHelper = {
+  findNodeType: findNodeType
+};
+
+exports.$$NodeList = $$NodeList;
+exports.$$HTMLCollection = $$HTMLCollection;
+exports.$$Node = $$Node;
+exports.$$Element = $$Element;
+exports.$$Document = $$Document;
+exports.$$Text = $$Text;
+exports.NodeTypeHelper = NodeTypeHelper;
+/* No side effect */

--- a/src/types/DOMAPI.res
+++ b/src/types/DOMAPI.res
@@ -115,7 +115,7 @@ module Element = {
     })
 
     @send
-    external getBoundingClientRect: T.t => ReactNative.Rect.t = "getBoundingClientRect"
+    external getBoundingClientRect: T.t => Rect.t = "getBoundingClientRect"
     @send
     external hasPointerCapture: (T.t, int) => bool = "hasPointerCapture"
     @send

--- a/src/types/DOMAPI.res
+++ b/src/types/DOMAPI.res
@@ -20,25 +20,27 @@ type readOnlyNode<'node, 'document, 'element> = {
   textContent: string,
 }
 
+type unknownNativeElement
+
 type rec node = {
-  ...readOnlyNode<node, document, element>,
+  ...readOnlyNode<node, document, anyElement>,
 }
 
-and element = {
+and element<'nativeElement> = {
   // Node
-  ...readOnlyNode<node, document, element>,
+  ...readOnlyNode<node, document, anyElement>,
   // Element
   childElementCount: int,
-  children: htmlCollection<element>,
+  children: htmlCollection<anyElement>,
   clientHeight: int,
   clientLeft: int,
   clientTop: int,
   clientWidth: int,
-  firstElementChild: Js.Null.t<element>,
+  firstElementChild: Js.Null.t<anyElement>,
   id: string,
-  lastElementChild: Js.Null.t<element>,
-  nextElementSibling: Js.Null.t<element>,
-  previousElementSibling: Js.Null.t<element>,
+  lastElementChild: Js.Null.t<anyElement>,
+  nextElementSibling: Js.Null.t<anyElement>,
+  previousElementSibling: Js.Null.t<anyElement>,
   scrollHeight: int,
   scrollLeft: int,
   scrollTop: int,
@@ -49,27 +51,29 @@ and element = {
   offsetLeft: int,
   offsetTop: int,
   offsetWidth: int,
-  offsetParent: Js.Null.t<element>,
+  offsetParent: Js.Null.t<anyElement>,
 }
 
 and text = {
   // Node
-  ...readOnlyNode<node, document, element>,
+  ...readOnlyNode<node, document, anyElement>,
   // CharacterData
   data: string,
   length: int,
-  nextElementSibling: Js.Null.t<element>,
-  previousElementSibling: Js.Null.t<element>,
+  nextElementSibling: Js.Null.t<anyElement>,
+  previousElementSibling: Js.Null.t<anyElement>,
 }
 
 and document = {
-  ...readOnlyNode<node, document, element>,
+  ...readOnlyNode<node, document, anyElement>,
   childElementCount: int,
-  children: htmlCollection<element>,
-  documentElement: element,
-  firstElementChild: Js.Null.t<element>,
-  lastElementChild: Js.Null.t<element>,
+  children: htmlCollection<anyElement>,
+  documentElement: anyElement,
+  firstElementChild: Js.Null.t<anyElement>,
+  lastElementChild: Js.Null.t<anyElement>,
 }
+
+and anyElement = element<unknownNativeElement>
 
 module NodeList = {
   @send
@@ -129,7 +133,7 @@ module Element = {
   }
 
   include Impl({
-    type t = element
+    type t = anyElement
   })
 }
 
@@ -138,7 +142,8 @@ module Document = {
     type t = document
   })
 
-  @send external getElementById: (document, string) => Js.Null.t<element> = "getElementById"
+  @send
+  external getElementById: (document, string) => Js.Null.t<anyElement> = "getElementById"
 }
 
 module Text = {
@@ -165,7 +170,7 @@ module NodeType = {
   and remove this helper
  */
   type t =
-    | Element(element)
+    | Element(element<unknownNativeElement>)
     | Text(text)
     | Document(document)
     | Unknown

--- a/src/types/DOMAPI.res
+++ b/src/types/DOMAPI.res
@@ -135,7 +135,7 @@ module Element = {
 
 module Document = {
   include Node.Impl({
-    type t = element
+    type t = document
   })
 
   @send external getElementById: (document, string) => element = "getElementById"
@@ -143,13 +143,13 @@ module Document = {
 
 module Text = {
   include Node.Impl({
-    type t = element
+    type t = text
   })
 
   @send external substringData: (text, ~offset: int, ~count: int) => unit = "substringData"
 }
 
-module NodeTypeHelper = {
+module NodeType = {
   /*
   Helper for handle NodeType
   Waiting for this issue :
@@ -170,7 +170,7 @@ module NodeTypeHelper = {
     | Document(document)
     | Unknown
 
-  let findNodeType = (node: node) =>
+  let classify = (node: node) =>
     switch node {
     | {nodeType: 1} => Element(node->Obj.magic)
     | {nodeType: 3} => Text(node->Obj.magic)

--- a/src/types/DOMAPI.res
+++ b/src/types/DOMAPI.res
@@ -1,0 +1,180 @@
+@@warning("-30")
+
+type nodeList<'node> = {length: int}
+type htmlCollection<'element> = {length: int}
+
+type readOnlyNode<'node, 'document, 'element> = {
+  // Node
+  childNodes: nodeList<'node>,
+  firstChild: Js.Null.t<'node>,
+  isConnected: bool,
+  lastChild: Js.Null.t<'node>,
+  nextSibling: Js.Null.t<'node>,
+  nodeType: int,
+  nodeName: string,
+  nodeValue: Js.Null.t<string>,
+  ownerDocument: Js.Null.t<'document>,
+  parentElement: Js.Null.t<'element>,
+  parentNode: Js.Null.t<'node>,
+  previousSibling: Js.Null.t<'node>,
+  textContent: string,
+}
+
+type rec node = {
+  ...readOnlyNode<node, document, element>,
+}
+
+and element = {
+  // Node
+  ...readOnlyNode<node, document, element>,
+  // Element
+  childElementCount: int,
+  children: htmlCollection<element>,
+  clientHeight: int,
+  clientLeft: int,
+  clientTop: int,
+  clientWidth: int,
+  firstElementChild: Js.Null.t<element>,
+  id: string,
+  lastElementChild: Js.Null.t<element>,
+  nextElementSibling: Js.Null.t<element>,
+  previousElementSibling: Js.Null.t<element>,
+  scrollHeight: int,
+  scrollLeft: int,
+  scrollTop: int,
+  scrollWidth: int,
+  tagName: string,
+  // HTMLElement
+  offsetHeight: int,
+  offsetLeft: int,
+  offsetTop: int,
+  offsetWidth: int,
+  offsetParent: Js.Null.t<element>,
+}
+
+and text = {
+  // Node
+  ...readOnlyNode<node, document, element>,
+  // CharacterData
+  data: string,
+  length: int,
+  nextElementSibling: Js.Null.t<element>,
+  previousElementSibling: Js.Null.t<element>,
+}
+
+and document = {
+  ...readOnlyNode<node, document, element>,
+  childElementCount: int,
+  children: htmlCollection<element>,
+  documentElement: element,
+  firstElementChild: Js.Null.t<element>,
+  lastElementChild: Js.Null.t<element>,
+}
+
+module NodeList = {
+  @send
+  external item: (nodeList<'node>, int) => Js.Null.t<'node> = "item"
+}
+
+module HTMLCollection = {
+  @send
+  external item: (htmlCollection<'element>, int) => Js.Null.t<'element> = "item"
+
+  @send
+  external namedItem: (htmlCollection<'element>, string) => Js.Null.t<'element> = "namedItem"
+}
+
+module Node = {
+  module Impl = (
+    T: {
+      type t
+    },
+  ) => {
+    external asNode: T.t => node = "%identity"
+
+    @send
+    external compareDocumentPosition: (T.t, node) => int = "compareDocumentPosition"
+    @send external contains: (T.t, node) => bool = "contains"
+    @send external getRootNode: T.t => T.t = "getRootNode"
+    @send external hasChildNodes: T.t => bool = "hasChildNodes"
+  }
+
+  include Impl({
+    type t = node
+  })
+}
+
+module Element = {
+  module Impl = (
+    T: {
+      type t
+    },
+  ) => {
+    include Node.Impl({
+      type t = T.t
+    })
+
+    @send
+    external getBoundingClientRect: T.t => ReactNative.Rect.t = "getBoundingClientRect"
+    @send
+    external hasPointerCapture: (T.t, int) => bool = "hasPointerCapture"
+    @send
+    external releasePointerCapture: (T.t, int) => unit = "releasePointerCapture"
+    @send
+    external setPointerCapture: (T.t, int) => unit = "setPointerCapture"
+    @send external focus: T.t => unit = "focus"
+    @send external blur: T.t => unit = "blur"
+
+    @send external setNativeProps: (T.t, {..}) => unit = "setNativeProps"
+  }
+
+  include Impl({
+    type t = element
+  })
+}
+
+module Document = {
+  include Node.Impl({
+    type t = element
+  })
+
+  @send external getElementById: (document, string) => element = "getElementById"
+}
+
+module Text = {
+  include Node.Impl({
+    type t = element
+  })
+
+  @send external substringData: (text, ~offset: int, ~count: int) => unit = "substringData"
+}
+
+module NodeTypeHelper = {
+  /*
+  Helper for handle NodeType
+  Waiting for this issue :
+  https://github.com/rescript-lang/rescript/issues/8280
+  to use this type for node instead
+
+  @tag("nodeType")
+  type rec node =
+    | @as(1) Element(element)
+    | @as(3) Text(text)
+    | @as(9) Document(document)
+
+  and remove this helper
+ */
+  type t =
+    | Element(element)
+    | Text(text)
+    | Document(document)
+    | Unknown
+
+  let findNodeType = (node: node) =>
+    switch node {
+    | {nodeType: 1} => Element(node->Obj.magic)
+    | {nodeType: 3} => Text(node->Obj.magic)
+    | {nodeType: 9} => Document(node->Obj.magic)
+    | _ => Unknown
+    }
+}

--- a/src/types/DOMAPI.res
+++ b/src/types/DOMAPI.res
@@ -95,7 +95,7 @@ module Node = {
     @send
     external compareDocumentPosition: (T.t, node) => int = "compareDocumentPosition"
     @send external contains: (T.t, node) => bool = "contains"
-    @send external getRootNode: T.t => T.t = "getRootNode"
+    @send external getRootNode: T.t => node = "getRootNode"
     @send external hasChildNodes: T.t => bool = "hasChildNodes"
   }
 
@@ -138,7 +138,7 @@ module Document = {
     type t = document
   })
 
-  @send external getElementById: (document, string) => element = "getElementById"
+  @send external getElementById: (document, string) => Js.Null.t<element> = "getElementById"
 }
 
 module Text = {
@@ -146,7 +146,7 @@ module Text = {
     type t = text
   })
 
-  @send external substringData: (text, ~offset: int, ~count: int) => unit = "substringData"
+  @send external substringData: (text, ~offset: int, ~count: int) => string = "substringData"
 }
 
 module NodeType = {

--- a/src/types/DOMAPI.res
+++ b/src/types/DOMAPI.res
@@ -17,7 +17,7 @@ type readOnlyNode<'node, 'document, 'element> = {
   parentElement: Js.Null.t<'element>,
   parentNode: Js.Null.t<'node>,
   previousSibling: Js.Null.t<'node>,
-  textContent: string,
+  textContent: Js.Null.t<string>,
 }
 
 type unknownNativeElement


### PR DESCRIPTION
Blog Post : [Starting from React Native 0.82, native components will provide DOM-like nodes via refs.](https://reactnative.dev/blog/2025/10/08/react-native-0.82#dom-node-apis)
Documentation : [Nodes from refs](https://reactnative.dev/docs/nodes)

---

I tried to follow the approach used in [experimental-rescript-webapi](https://github.com/rescript-lang/experimental-rescript-webapi) but I hope this [rescript feature](https://github.com/rescript-lang/rescript/issues/8280) for tagged variants can be addressed soon, as it would provide a better DX.

In the meantime, I added a `NodeTypeHelper` module to help with type conversions.
I know it doesn’t follow the zero-runtime binding rule, but while experimenting with `experimental-rescript-webapi`, I found this kind of helper quite useful, and it would otherwise have to be reimplemented in every project.