### PR TITLE
ImageBackground: add missing children prop

### DIFF
--- a/src/components/ImageBackground.res
+++ b/src/components/ImageBackground.res
@@ -8,6 +8,7 @@ type props = {
   ref?: ref,
   imageRef?: Image.ref,
   imageStyle?: Style.t,
+  children?: React.element,
   ...Image.imageProps,
 }
 


### PR DESCRIPTION
Somehow, ImageBackground's children prop seems to have got lost recently.